### PR TITLE
fix bug ‘struct bts::bitname::name_record’ has no member named ‘pub_key’

### DIFF
--- a/AddressBook/ContactView.cpp
+++ b/AddressBook/ContactView.cpp
@@ -124,7 +124,7 @@ void ContactView::onSave()
        //_current_contact.bit_id_hash = _current_record->name_hash;
        if( !_current_contact.public_key.valid() )
        {
-            _current_contact.public_key = _current_record->pub_key;
+            _current_contact.public_key = _current_record->active_key;
             FC_ASSERT( _current_contact.public_key.valid() );
        }
        // TODO: lookup block id / timestamp that registered this ID
@@ -445,7 +445,7 @@ void ContactView::lookupId()
        {
             ui->id_status->setStyleSheet("QLabel { color : green; }");
             ui->id_status->setText( tr( "Registered" ) );
-            std::string public_key_string = public_key_address(_current_record->pub_key);
+            std::string public_key_string = public_key_address(_current_record->active_key);
             ui->public_key->setText( public_key_string.c_str() );
             if( _address_book != nullptr )
                ui->save_button->setEnabled(true);


### PR DESCRIPTION
/home/jeffrey/Git/keyhotee/AddressBook/ContactView.cpp: In member function ‘void ContactView::onSave()’:
/home/jeffrey/Git/keyhotee/AddressBook/ContactView.cpp:127:60: error: ‘struct bts::bitname::name_record’ has no member named ‘pub_key’
/home/jeffrey/Git/keyhotee/AddressBook/ContactView.cpp: In member function ‘void ContactView::lookupId()’:
/home/jeffrey/Git/keyhotee/AddressBook/ContactView.cpp:448:81: error: ‘struct bts::bitname::name_record’ has no member named ‘pub_key’

struct name_record not contain pub_key,I guess shuld be active_key.
name_record
BitShares/include/bts/bitname_record.hpp
struct name_record
  {
     name_record()
     :revoked(false),age(0),repute(0){}

```
 /** handle to/from hex conversion */
 uint64_t get_name_hash()const;
 void     set_name_hash( uint64_t h );

 fc::time_point_sec          last_update; ///< the most recent update of this name
 fc::ecc::public_key_data    master_key;  ///< the public key paired to this name.
 fc::ecc::public_key_data    active_key;  ///< the public key paired to this name.
 bool                        revoked;     ///< this name has been canceled, by its owner (invalidating the public key)
 uint32_t                    age;         ///< first block this name was registered in
 uint32_t                    repute;      ///< how many repute points have been earned by this name
 std::string                 name_hash;   ///< the unique hash assigned to this name, in hex format
 fc::optional<std::string>   name;        ///< if we know the name that generated the hash
```

  };
