### PR TITLE
fix bug: upnp.cpp:78: undefined reference to upnpDiscover

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,7 +182,7 @@ list(APPEND sources "${CMAKE_CURRENT_BINARY_DIR}/GitSHA1.cpp" GitSHA1.h)
 add_library( keyhotee_library ${library_sources} )
 qt5_use_modules(keyhotee_library Widgets WebKit)
 message(BOOST_LIBRARIES=${BOOST_LIBRARIES})
-target_link_libraries( keyhotee_library upnpc-static bshare fc leveldb ${BOOST_LIBRARIES} ${PLATFORM_SPECIFIC_LIBS} ${QtMacExtras} ${APPKIT_LIBRARY})
+target_link_libraries( keyhotee_library upnpc-static bshare fc miniupnpc leveldb ${BOOST_LIBRARIES} ${PLATFORM_SPECIFIC_LIBS} ${QtMacExtras} ${APPKIT_LIBRARY})
 
 # Let's configure binaries output directory (by default invictus-root/bin)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY $ENV{INVICTUS_ROOT}/bin)
@@ -199,7 +199,7 @@ set_target_properties( Keyhotee PROPERTIES OUTPUT_NAME_RELEASE Keyhotee )
 # Use the Widgets module from Qt 5.
 qt5_use_modules(Keyhotee Widgets PrintSupport WebKit)
 
-target_link_libraries( Keyhotee keyhotee_library upnpc-static bshare fc leveldb ${BOOST_LIBRARIES} ${PLATFORM_SPECIFIC_LIBS} ${QtMacExtras} ${APPKIT_LIBRARY})
+target_link_libraries( Keyhotee keyhotee_library upnpc-static bshare fc miniupnpc leveldb ${BOOST_LIBRARIES} ${PLATFORM_SPECIFIC_LIBS} ${QtMacExtras} ${APPKIT_LIBRARY})
 
 if (MSVC)
   message("Setting up debug options for MSVC build")


### PR DESCRIPTION
My OS is Ubuntu 12.04.3.
fix this make error:
[ 69%] Built target Keyhotee_automoc
Linking CXX executable bin/Keyhotee
BitShares/libbshare.a(upnp.cpp.o): In function `operator()':
/home/jeffrey/Git/keyhotee/BitShares/src/network/upnp.cpp:78: undefined reference to`upnpDiscover'
/home/jeffrey/Git/keyhotee/BitShares/src/network/upnp.cpp:86: undefined reference to `UPNP_GetValidIGD'
/home/jeffrey/Git/keyhotee/BitShares/src/network/upnp.cpp:145: undefined reference to`freeUPNPDevlist'
/home/jeffrey/Git/keyhotee/BitShares/src/network/upnp.cpp:148: undefined reference to `FreeUPNPUrls'
/home/jeffrey/Git/keyhotee/BitShares/src/network/upnp.cpp:96: undefined reference to`UPNP_GetExternalIPAddress'
/home/jeffrey/Git/keyhotee/BitShares/src/network/upnp.cpp:125: undefined reference to `strupnperror'
/home/jeffrey/Git/keyhotee/BitShares/src/network/upnp.cpp:120: undefined reference to`UPNP_AddPortMapping'
/home/jeffrey/Git/keyhotee/BitShares/src/network/upnp.cpp:136: undefined reference to `UPNP_DeletePortMapping'
/home/jeffrey/Git/keyhotee/BitShares/src/network/upnp.cpp:138: undefined reference to`freeUPNPDevlist'
/home/jeffrey/Git/keyhotee/BitShares/src/network/upnp.cpp:139: undefined reference to `FreeUPNPUrls'
