### PR TITLE
Fix link errors when boost version larger or equal than 1.54 on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,11 @@ IF( WIN32 )
   set(Boost_USE_STATIC_LIBS OFF)
   set(BOOST_ALL_DYN_LINK ON) # force dynamic linking for all libraries
 
-  FIND_PACKAGE(Boost 1.53 REQUIRED COMPONENTS thread date_time system filesystem program_options signals serialization chrono unit_test_framework context) 
+  FIND_PACKAGE(Boost 1.53 REQUIRED COMPONENTS thread date_time system filesystem program_options signals serialization chrono unit_test_framework context)
+  # For Boost 1.53 on windows, coroutine was not in BOOST_LIBRARYDIR and do not need it to build,  but if boost versin >= 1.54, find coroutine otherwise will cause link errors
+  IF(NOT "${Boost_VERSION}" MATCHES "1.53(.*)")
+	FIND_PACKAGE(Boost 1.54 REQUIRED COMPONENTS coroutine)
+  ENDIF()
 
   include_directories( ${BITSHARES_DIR}/vendor/leveldb-win/include )
 ELSE(WIN32)


### PR DESCRIPTION
boost 1.53 was lost from boost library dir on windows, but do not affect build.

for boost version >= 1.54, missing coroutine will cause link errors.

This fix will not affect boost 1.53
