### PR TITLE
fiexed:Mailbox.hpp:55:8: error: extra qualification ‘Mailbox::’ on membe...

### DIFF
--- a/Mail/Mailbox.hpp
+++ b/Mail/Mailbox.hpp
@@ -52,7 +52,7 @@ private:
   void onSelectionChanged(const QItemSelection& selected, const QItemSelection& deselected);
   void selectNextRow(int idx, int deletedRowCount) const;
   void duplicateMail(ReplyType);
-  bool Mailbox::getSelectedMessageData (IMailProcessor::TStoredMailMessage* encodedMsg, 
+  bool getSelectedMessageData (IMailProcessor::TStoredMailMessage* encodedMsg,
                              IMailProcessor::TPhysicalMailMessage* decodedMsg);
 
 public slots:


### PR DESCRIPTION
OS:Ubuntu 12.04 linux
gcc:4.8.1

[ 70%] Building CXX object CMakeFiles/Keyhotee.dir/Mail/Mailbox.cpp.o
In file included from /home/jeffrey/Git/keyhotee/Mail/Mailbox.cpp:1:0:
/home/jeffrey/Git/keyhotee/Mail/Mailbox.hpp:55:8: error: extra qualification ‘Mailbox::’ on member ‘getSelectedMessageData’ [-fpermissive]
   bool Mailbox::getSelectedMessageData (IMailProcessor::TStoredMailMessage\* encodedMsg, 
        ^
