### PR TITLE
Fixed mac os compilation on 10.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,7 +134,7 @@ message(STATUS "Using invictus root: " ${INVICTUS_ROOT})
 IF( APPLE )
     SET(KH_STATIC_QT 0)
 
-    SET(CMAKE_CXX_FLAGS "-std=c++11")
+    SET(CMAKE_CXX_FLAGS "-std=c++11 -stdlib=libc++")
 
     SET_SOURCE_FILES_PROPERTIES(
                                 "images/keyhotee.icns"

--- a/miner/CMakeLists.txt
+++ b/miner/CMakeLists.txt
@@ -8,7 +8,7 @@ if( UNIX AND NOT APPLE )
   set(rt_library rt )
 endif()
 if( APPLE )
-    SET(CMAKE_CXX_FLAGS "-std=c++11")
+    SET(CMAKE_CXX_FLAGS "-std=c++11 -stdlib=libc++")
 endif()
 
 SET (CMAKE_FIND_LIBRARY_SUFFIXES ${MINER_ORIGINAL_LIB_SUFFIXES})


### PR DESCRIPTION
This fixes compilation on osx 10.8 by linking against libc++ (default in 10.9 but needs to be set explicitly in 10.8)
